### PR TITLE
Introduce function-as-child for <Marking> component

### DIFF
--- a/.changeset/calm-dolphins-serve.md
+++ b/.changeset/calm-dolphins-serve.md
@@ -1,0 +1,7 @@
+---
+"@markings/react": minor
+"@markings/source-react": minor
+"@markings/test-project": minor
+---
+
+Introduce function-as-a-child for React <Marking> component which doesn't require injecting { display: 'contents' }

--- a/.changeset/calm-dolphins-serve.md
+++ b/.changeset/calm-dolphins-serve.md
@@ -1,6 +1,5 @@
 ---
 "@markings/react": minor
-"@markings/source-react": minor
 "@markings/test-project": minor
 ---
 

--- a/packages/react/src/marking/Note.tsx
+++ b/packages/react/src/marking/Note.tsx
@@ -15,6 +15,15 @@ import { MarkingPanel } from "./NotePanel";
 
 type RecordOfMarkings = { [id: string]: MarkingType };
 
+type MarkingProps = {
+  'data-marking-id'?: string
+};
+
+type MarkingChildCompOrFunc = { children: ReactNode }
+  | { children: (markingProps: MarkingProps) => ReactNode };
+
+type MarkingComponentType = MarkingType & MarkingChildCompOrFunc;
+
 // Provider
 // ------------------------------
 
@@ -59,10 +68,14 @@ export const MarkingProvider = ({
 export const Marking = ({
   children,
   ...props
-}: MarkingType & { children: ReactNode }): ReactElement => {
+}: MarkingComponentType): ReactElement => {
   const { register, unregister, enabled } = useMarkingRegistry();
   if (!enabled) {
-    return children as any;
+    if (typeof children === 'function') {
+      return children({}) as any;
+    } else {
+      return children as any;
+    }
   }
   // TODO: notes should have a unique id and we should use that instead
   const id = useMemo(
@@ -77,9 +90,13 @@ export const Marking = ({
     };
   }, []);
 
-  return (
-    <div data-marking-id={id} style={{ display: "contents" }}>
-      {children}
-    </div>
-  );
+  if (typeof children === 'function') {
+    return children({ 'data-marking-id': id }) as any;
+  } else {
+    return (
+      <div data-marking-id={id} style={{ display: "contents" }}>
+        {children}
+      </div>
+    );
+  }
 };

--- a/packages/source-react/src/__fixtures__/with-child-comp.js
+++ b/packages/source-react/src/__fixtures__/with-child-comp.js
@@ -1,0 +1,3 @@
+<Marking description="something" purpose="question">
+  <span>Hi</span>
+</Marking>;

--- a/packages/source-react/src/__fixtures__/with-child-func.js
+++ b/packages/source-react/src/__fixtures__/with-child-func.js
@@ -1,0 +1,3 @@
+<Marking description="something" purpose="question">
+  {(props) => <span {...props}>Hi</span>}
+</Marking>;

--- a/packages/source-react/src/__snapshots__/index.test.ts.snap
+++ b/packages/source-react/src/__snapshots__/index.test.ts.snap
@@ -1,5 +1,41 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`with-child-comp 1`] = `
+<Marking description="something" purpose="question">
+  <span>Hi</span>
+</Marking>;
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+[
+  {
+    "description": "something",
+    "purpose": "question",
+    "location": {
+      "line": 1
+    }
+  }
+]
+`;
+
+exports[`with-child-func 1`] = `
+<Marking description="something" purpose="question">
+  {(props) => <span {...props}>Hi</span>}
+</Marking>;
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+[
+  {
+    "description": "something",
+    "purpose": "question",
+    "location": {
+      "line": 1
+    }
+  }
+]
+`;
+
 exports[`with-purpose 1`] = `
 <Marking description="something" purpose="question" />;
 

--- a/test-project/pages/index.css
+++ b/test-project/pages/index.css
@@ -17,3 +17,12 @@ code {
 img {
   max-width: 100%;
 }
+
+.stack {
+  display: flex;
+  flex-direction: column;
+}
+
+.stack > *:not(style) ~ *:not(style) {
+  margin-top: 1rem;
+}

--- a/test-project/pages/index.tsx
+++ b/test-project/pages/index.tsx
@@ -14,27 +14,40 @@ export default () => (
     <h1>Markings: Note</h1>
     <p>This is the dev environment for building markings' UI.</p>
     <hr />
-    <Marking
-      description="Spike how easy it would be to enhance the view panel with issue data"
-      purpose="todo"
-    >
-      <p>I should have a related note...</p>
-    </Marking>
-    {paragraphArray.map((p, i) => (
-      <Marking key={i} description={p} purpose={i > 9 ? "todo" : "question"}>
-        <p>I should have a related note...</p>
+    <div className="stack">
+      <span>Some content</span>
+      <span>Some more content</span>
+      <Marking
+        description="Spike how easy it would be to enhance the view panel with issue data"
+        purpose="todo"
+      >
+        <span>I should have a related note...</span>
       </Marking>
-    ))}
+      {childCompArray.map((p, i) => (
+        <Marking key={i} description={p} purpose={i > 9 ? "todo" : "question"}>
+          <span>I should have a related note...</span>
+        </Marking>
+      ))}
+      {childFuncArray.map((p, i) => (
+        <Marking key={i} description={p} purpose={i > 9 ? "todo" : "question"}>
+          {(markingProps) => (
+            <span {...markingProps}>I should have a related note...</span>
+          )}
+        </Marking>
+      ))}
+    </div>
   </div>
 );
 
-const paragraphArray = [
+const childCompArray = [
   "Amet soufflé carrot cake tootsie roll jelly-o chocolate cake.",
   "Chocolate bar gummies sweet roll macaroon powder sweet tart croissant.",
   "Pastry ice cream bear claw cupcake topping caramels jelly beans chocolate cheesecake.",
   "Candy canes pastry cake tart powder.",
   "Tootsie roll bear claw sesame snaps candy cheesecake caramels cookie.",
   "Lemon drops donut marzipan gummi bears cotton candy cotton candy jelly-o carrot cake.",
+];
+const childFuncArray = [
   "Lemon drops pastry apple pie biscuit tart tootsie roll.",
   "Brownie icing chupa chups cake cookie halvah gummi bears halvah.",
   "Sesame snaps donut gingerbread marshmallow topping powder.",


### PR DESCRIPTION
Fixes #27 

Test project now looks like:

<img width="412" alt="Screen Shot 2020-09-11 at 1 16 47 pm" src="https://user-images.githubusercontent.com/612020/92851595-191b0f00-f431-11ea-9976-22af56f34ef1.png">

The first (compact) batch uses the existing `<Marking><span>` way, and the second (spaced) uses the new `<Marking>{(markingProps) => <span {...markingProps}>` way.